### PR TITLE
Added Simon Tatham's Puzzles under Games

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ __AWESOME__ apps counter: __100__ 🎉
 - [x] [Official page](https://mindustrygame.github.io/)
 
 ### Simon Tatham's Puzzles
-<img alt="Simon Tatham's Puzzles" height="64" src="https://play-lh.googleusercontent.com/vQrvKLasmRqdHbPc4V7fQgSHfO6Fw1nthYY9gFMA-FnDi5DposxKU6-th_gXa6qDUDdW">
+<img alt="Simon Tatham's Puzzles" height="64" src="https://github.com/chrisboyle/sgtpuzzles/blob/main/app/src/main/res/mipmap-hdpi/ic_launcher.png">
 
 - [x] [Google Play](https://play.google.com/store/apps/details?id=name.boyle.chris.sgtpuzzles&gl)
 - [x] [F-Droid](https://f-droid.org/en/packages/name.boyle.chris.sgtpuzzles/)

--- a/README.md
+++ b/README.md
@@ -473,6 +473,14 @@ __AWESOME__ apps counter: __100__ 🎉
 - [x] [GitHub](https://github.com/Anuken/Mindustry)
 - [x] [Official page](https://mindustrygame.github.io/)
 
+### Simon Tatham's Puzzles
+<img alt="Simon Tatham's Puzzles" height="64" src="https://play-lh.googleusercontent.com/vQrvKLasmRqdHbPc4V7fQgSHfO6Fw1nthYY9gFMA-FnDi5DposxKU6-th_gXa6qDUDdW">
+
+- [x] [Google Play](https://play.google.com/store/apps/details?id=name.boyle.chris.sgtpuzzles&gl)
+- [x] [F-Droid](https://f-droid.org/en/packages/name.boyle.chris.sgtpuzzles/)
+- [x] [GitHub](https://github.com/chrisboyle/sgtpuzzles)
+- [x] [Official page](https://chris.boyle.name/projects/android-puzzles/)
+
 ## GitHub Client
 ### OpenHub
 <img alt="OpenHub" height="64" src="https://github.com/ThirtyDegreesRay/OpenHub/blob/master/app/src/main/res/mipmap-hdpi/logo.png?raw=true">


### PR DESCRIPTION
This is a port of [Simon Tatham’s Portable Puzzle Collection](https://www.chiark.greenend.org.uk/~sgtatham/puzzles/), a collection of 40 single-player logic games. It’s free, with no ads, and is playable offline. All games are generated on demand with adjustable size and difficulty, so you’ll never run out of puzzles.