### PR TITLE
Add official site to PixaPencil

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ __AWESOME__ apps counter: __173__ 🎉
 - [ ] Google Play
 - [x] [F-Droid](https://f-droid.org/en/packages/com.therealbluepandabear.pixapencil/)
 - [x] [GitHub](https://github.com/therealbluepandabear/PixaPencil)
-- [ ] Official page
+- [x] [Official page](https://pixapencil.github.io/)
 
 ## E-book Reader
 ### Librera Reader


### PR DESCRIPTION
Hey (creator of PixaPencil here),

Appreciate the inclusion of my app.

A couple of days ago I created a website for my app (https://pixapencil.github.io/).

I made this PR so that now the 'website' part is checked, since the app now has its own official website.

Regards
thebluepandabear