### PR TITLE
Replace QR app

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,13 +301,13 @@ F-Droid version is outdated compared to GitHub's.
 - [x] [GitHub](https://github.com/markusfisch/BinaryEye)
 - [ ] Official page
 
-### QR & Barcode Scanner
-<img alt="QrAndBarcodeScanner" height="64" src="https://raw.githubusercontent.com/wewewe718/QrAndBarcodeScanner/master/images/google_play/market_app_icon.png">
+### QR Scanner (PFA)
+<img alt="PrivacyFriendlyQRScanner" height="64" src="https://raw.githubusercontent.com/SecUSo/privacy-friendly-qr-scanner/master/fastlane/metadata/android/en-US/images/icon.png">
 
-- [x] [Google Play](https://play.google.com/store/apps/details?id=org.barcodescanner)
-- [x] [F-Droid](https://www.f-droid.org/en/packages/com.example.barcodescanner/)
-- [x] [GitHub](https://github.com/wewewe718/QrAndBarcodeScanner)
-- [ ] Official page
+- [x] [Google Play](https://play.google.com/store/apps/details?id=com.secuso.privacyFriendlyCodeScanner)
+- [x] [F-Droid](https://f-droid.org/packages/com.secuso.privacyFriendlyCodeScanner/)
+- [x] [GitHub](https://github.com/SecUSo/privacy-friendly-qr-scanner)
+- [x] [Official page](https://secuso.aifb.kit.edu/english/QR_Scanner.php)
 
 ### SecScanQR
 <img alt="SecScanQR" height="64" src="https://github.com/Fr4gorSoftware/SecScanQR/blob/master/pictures/web_hi_res_512.png">


### PR DESCRIPTION
"QR & Barcode Scanner" sends requests to Sentry, and it has an issue on GitHub about data tracking, but the developer doesn't seem very active. I think it's better to remove it and to add an app that was excluded before because of the lack of the dark theme. A recent update added it and I think it's ready.

- [x] Installed and tested by me on my main smartphone and used for about 15 minutes or more.
- [x] Has dark theme.
- [x] It has x trackers on [εxodus](https://reports.exodus-privacy.eu.org/en/reports/com.secuso.privacyFriendlyCodeScanner/latest/).
- [x] It has x F-Droid [Anti-Features](https://f-droid.org/packages/com.secuso.privacyFriendlyCodeScanner/).
- [ ] I use the app on a daily basis and I love almost the entirety of it, so I placed next to it a heart.