### PR TITLE
added opencalc

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,14 @@ F-Droid version is outdated compared to GitHub's.
 - [x] [GitHub](https://github.com/prathameshmm02/Calculator-inator)
 - [ ] Official page
 
+### OpenCalc
+<img alt="OpenCalc" height="64" src="https://github.com/Darkempire78/OpenCalc/blob/main/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.png?raw=true">
+
+- [ ] Google Play
+- [x] [F-Droid](https://f-droid.org/en/packages/com.darkempire78.opencalculator/)
+- [x] [GitHub](https://github.com/Darkempire78/OpenCalc)
+- [ ] Official page
+
 ### Simple Calculator ❤️
 <img alt="SimpleCalculator" height="64" src="https://github.com/SimpleMobileTools/Simple-Calculator/raw/master/fastlane/metadata/android/en-US/images/icon.png">
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is a list of `THE BEST FOSS apps` according to [us](https://github.com/Psyh
 >
 >[More detailed explanation here.](RULES.md)
 
-__AWESOME__ apps counter: __199__ 🎉
+__AWESOME__ apps counter: __200__ 🎉
 
 ### Contents:
 - [2FA](#2fa)


### PR DESCRIPTION
## OpenCalc
- [x] Installed and tested by me on my main smartphone and used for about 15 minutes or more.
- [x] Has dark theme.
- [x] It has 0 trackers on [εxodus](https://reports.exodus-privacy.eu.org/en/reports/275645/#trackers).
- [x] It has 0 F-Droid [Anti-Features](https://f-droid.org/en/packages/com.darkempire78.opencalculator/).
- [ ] I use the app on a daily basis and I love almost the entirety of it, so I placed next to it a heart.