### PR TITLE
Cloudstream does not currently have a website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1421,7 +1421,7 @@ Currently being reworked as Neo Launcher.
 - [ ] Google Play
 - [x] [IzzyOnDroid](https://apt.izzysoft.de/fdroid/index/apk/com.lagradost.cloudstream3/)
 - [x] [GitHub](https://github.com/recloudstream/cloudstream)
-- [x] [Official page](https://cloudstream.ws)
+- [ ] Official page
 
 ### Burning-Series
 <img alt="Burning-Series" height="64" src="https://f-droid.org/repo/de.datlag.burningseries/en-US/icon_mn8-Wrvht9_iyE6QETjT1TkUaCtOThW2m8OQQfuJzfI=.png">


### PR DESCRIPTION
This is a unofficial fan website. The Dev's have said in the discord multiple times that this is not theirs. This means at anytime the owner could change the link to something malicious.