### PR TITLE
Add Kvaesitso

### DIFF
--- a/README.md
+++ b/README.md
@@ -1232,6 +1232,16 @@ Because the dev have decided to make repo private, I am crossing out this app fr
 
 ## Launcher
 
+### Kvaesitso :heart:
+
+<img alt="Kvaesitso" height="64" src="https://raw.githubusercontent.com/MM2-0/Kvaesitso/main/assets/icons/ic_launcher.png">
+
+- [ ] Google Play
+- [x] [F-Droid](https://f-droid.org/en/packages/de.mm20.launcher2.release/)
+- [x] [IzzyOnDroid](https://apt.izzysoft.de/fdroid/index/apk/de.mm20.launcher2.release) (feature completeness)
+- [x] [GitHub](https://github.com/MM2-0/Kvaesitso)
+- [x] [Official page](https://kvaesitso.mm20.de/)
+
 ### Lawnchair Launcher ❤️
 
 <img alt="LawnchairLauncher" height="64" src="https://avatars.githubusercontent.com/u/34144436?s=200&v=4">

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is a list of `THE BEST FOSS apps` according to [us](https://github.com/Psyh
 >
 >[More detailed explanation here.](RULES.md)
 
-__AWESOME__ apps counter: __217__ 🎉
+__AWESOME__ apps counter: __218__ 🎉
 
 ### Contents
 


### PR DESCRIPTION
## Kvaesitso
- [x] Installed and tested by me on my main smartphone and used for about 15 minutes or more.
- [x] Has dark theme and full Material-You support.
- [x] It has 0 trackers on [εxodus](https://reports.exodus-privacy.eu.org/en/reports/de.mm20.launcher2.release/latest/).
- [x] It has 2 F-Droid [Anti-Features](https://f-droid.org/en/packages/de.mm20.launcher2.release/).
- [x] I use the app on a daily basis and I love almost the entirety of it, so I placed next to it a heart.

Note on the anti-features:
F-Droid reports "upstream is not entirely free". The F-Droid version removes every blob that is non-free, so this shouldn't be an issue.
The app is also on Izzy, with full feature completeness.