### PR TITLE
Added Fcitx5 for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is a list of `THE BEST FOSS apps` according to [us](https://github.com/Psyh
 - [x] Has dark theme
   > [More detailed explanation here.](RULES.md)
 
-**AWESOME** apps counter: **266** 🎉
+**AWESOME** apps counter: **267** 🎉
 
 ### Contents
 
@@ -1361,6 +1361,16 @@ This is a list of `THE BEST FOSS apps` according to [us](https://github.com/Psyh
 - [x] [IzzyOnDroid](https://apt.izzysoft.de/fdroid/index/apk/helium314.keyboard)
 - [x] [GitHub](https://github.com/Helium314/HeliBoard)
 - [ ] Official page
+
+### Fcitx5 for Android :heart:
+<img alt="Fcitx5ForAndroidIcon" height="64" src="https://raw.githubusercontent.com/fcitx5-android/fcitx5-android/master/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png">
+
+> Supports input for Chinese, Japanese, Korean, and more
+
+- [x] [Google Play](https://play.google.com/store/apps/details?id=org.fcitx.fcitx5.android)
+- [x] [F-Droid](https://f-droid.org/packages/org.fcitx.fcitx5.android/)
+- [x] [Source code](https://github.com/fcitx5-android/fcitx5-android)
+- [x] [Official page](https://fcitx5-android.github.io/en/)
 
 ### FlorisBoard
 


### PR DESCRIPTION
## Fcitx5 for Android
- [x] Installed and tested by me on my main smartphone and used for about 15 minutes or more.
- [x] Has dark theme.
- [x] It has 0 trackers on [εxodus](https://reports.exodus-privacy.eu.org/en/reports/org.fcitx.fcitx5.android/latest/).
- [x] It has 0 F-Droid [Anti-Features](https://f-droid.org/packages/org.fcitx.fcitx5.android/).
- [x] I use the app on a daily basis and I love almost the entirety of it, so I placed next to it a heart.