### PR TITLE
Adding fWallet and Accrescent

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is a list of `THE BEST FOSS apps` according to [us](https://github.com/Psyh
 - [x] Has dark theme
   > [More detailed explanation here.](RULES.md)
 
-**AWESOME** apps counter: **267** 🎉
+**AWESOME** apps counter: **269** 🎉
 
 ### Contents
 
@@ -2657,7 +2657,7 @@ Currently being reworked as Neo Launcher.
 
 > A beautiful cross-platform wallet application for your transport tickets, discount cards and subscriptions.
 
-<img alt="fWalletIcon" height="64" src="https://gitlab.com/TheOneWithTheBraid/f_wallet/-/raw/main/assets/logo/logo-circle.png?ref_type=heads&inline=false">
+<img alt="fWalletIcon" height="64" src="https://gitlab.com/TheOneWithTheBraid/f_wallet/-/raw/main/assets/logo/logo-circle.svg">
 
 - [ ] Google Play
 - [x] [F-Droid](https://f-droid.org/packages/business.braid.f_wallet/)


### PR DESCRIPTION
Hi! I just found out two interesing apps that I want to add to the list!

One if fWallet, which is a passes / ticket / membership card manager which uses the pkpass format (the format used by Apple Wallet) I created the Wallet category for it but please tell me if you think there is a more appropriate one.

The Other app I am adding is Accrescent, a new F-Droid-like app, with its own repository of applications, so I added it under the Play Store category, since Obtainium is also there.

Let me know if I need to change anything and thanks for curating this list!